### PR TITLE
Use does for File::ChangeNotify::Watcher attr constraint in Restarter

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 This file documents the revision history for Perl extension Catalyst-Devel.
 
         - Typo fixes. RT#87103
+        - Require File::ChangeNotify 0.27+ to work around issues with earlier
+          File::ChangeNotify versions and Moose 2.2000+ (RT #120040).
 
 1.39 2013-06-14 12:44:17
         - Write =encoding utf8 into generated Pod files so that things

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,7 +19,7 @@ requires 'Catalyst::Action::RenderView' => '0.10';
 requires 'Catalyst::Plugin::Static::Simple' => '0.28';
 requires 'Catalyst::Plugin::ConfigLoader' => '0.30';
 requires 'Config::General' => '2.42'; # as of 1.07, we use .conf and not .yaml
-requires 'File::ChangeNotify' => '0.07';
+requires 'File::ChangeNotify' => '0.27';
 requires 'File::Copy::Recursive';
 requires 'Path::Class' => '0.09';
 requires 'Template'    => '2.14';

--- a/lib/Catalyst/Restarter.pm
+++ b/lib/Catalyst/Restarter.pm
@@ -22,8 +22,8 @@ has argv =>  (
 );
 
 has _watcher => (
-    is  => 'rw',
-    isa => 'File::ChangeNotify::Watcher',
+    is   => 'rw',
+    does => 'File::ChangeNotify::Watcher',
 );
 
 has _filter => (


### PR DESCRIPTION
The isa check actually works because Moose somehow does the right thing (I'm
not sure exactly how), but this is more correct. The Watcher has been a role
since 0.25.

This commit also requires File::ChangeNotify to work around issues with
File::ChangeNotify and Moose 2.2000+.